### PR TITLE
Remove the need to reference count and all the locks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["asynchronous", "concurrency"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+name = "benchmarks"
+harness = false
+
 [dependencies]
 tokio = { version = "^1.6.0", features = ["rt-multi-thread", "sync", "parking_lot"] }
 tokio-stream = { version = "~0.1.6", features = ["sync"] }
@@ -19,4 +23,5 @@ anyhow = "^1.0.40"
 [dev-dependencies]
 tokio = { version = "^1.6.0", features = ["rt-multi-thread", "sync", "parking_lot", "macros", "test-util"] }
 deno_core = "~0.88.0"
-criterion = "~0.3.4"
+criterion = { version = "~0.3.4", features = ["async_tokio", "html_reports"] }
+futures = "~0.3.15"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,93 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use tokio_stream::StreamExt;
+use message_worker::EmptyCtx;
+use anyhow::Result;
+
+use message_worker::{blocking, non_blocking};
+
+pub fn listener_creation(c: &mut Criterion) {
+    c.bench_function("create listener", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = tokio_stream::iter(vec![()]);
+            non_blocking::listen(source, || EmptyCtx, handle_message);
+        })
+    });
+}
+
+pub fn listener_process_one(c: &mut Criterion) {
+    c.bench_function("listener process 1 message", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = tokio_stream::iter(vec![()]);
+            non_blocking::listen(source, || EmptyCtx, handle_message).await.unwrap();
+        })
+    });
+}
+
+pub fn listener_process_many(c: &mut Criterion) {
+    c.bench_function("listener process 1000 messages", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = futures::stream::repeat(()).take(1000);
+            non_blocking::listen(source, || EmptyCtx, handle_message).await.unwrap();
+        })
+    });
+}
+
+pub fn blocking_listener_creation(c: &mut Criterion) {
+    c.bench_function("(blocking) create listener", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = tokio_stream::iter(vec![()]);
+            blocking::listen(source, || EmptyCtx, handle_message);
+        })
+    });
+}
+
+pub fn blocking_listener_process_one(c: &mut Criterion) {
+    c.bench_function("(blocking) listener process 1 message", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = tokio_stream::iter(vec![()]);
+            blocking::listen(source, || EmptyCtx, handle_message).await.unwrap();
+        })
+    });
+}
+
+pub fn blocking_listener_process_many(c: &mut Criterion) {
+    c.bench_function("(blocking) listener process 1000 messages", |b| {
+        let executor = tokio::runtime::Runtime::new().unwrap();
+        async fn handle_message(_ctx: &mut EmptyCtx, _event: ()) -> Result<()> { Ok(()) }
+
+        b.to_async(executor).iter(move || async {
+            let source = futures::stream::repeat(()).take(1000);
+            blocking::listen(source, || EmptyCtx, handle_message).await.unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    listener_creation,
+    listener_process_one,
+    listener_process_many,
+    blocking_listener_creation,
+    blocking_listener_process_one,
+    blocking_listener_process_many
+);
+criterion_main!(benches);

--- a/examples/pingpong/src/main.rs
+++ b/examples/pingpong/src/main.rs
@@ -2,11 +2,10 @@ use anyhow::{Result, bail, Error, anyhow};
 use message_worker::{Context, ThreadSafeContext, EmptyCtx};
 use message_worker::non_blocking::{listen, listen_with_error_handler};
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
-struct ActorCtx { output: RwLock<tokio::sync::broadcast::Sender<Message>> }
+struct ActorCtx { output: tokio::sync::broadcast::Sender<Message> }
 impl Context for ActorCtx {} impl ThreadSafeContext for ActorCtx {}
 
 // Create our messages
@@ -17,11 +16,7 @@ enum Message { Ping, Pong }
 async fn ping_actor(ctx: Arc<ActorCtx>, event: Message) -> Result<()> {
     match event {
         Message::Ping => bail!("I'm meant to be the pinger!"),
-        Message::Pong =>
-            ctx.output
-                .write().await
-                .send(Message::Ping)
-                .map_err(|err| anyhow!(err))?
+        Message::Pong => ctx.output.send(Message::Ping).map_err(|err| anyhow!(err))?
     };
     Ok(())
 }
@@ -29,11 +24,7 @@ async fn ping_actor(ctx: Arc<ActorCtx>, event: Message) -> Result<()> {
 // Create the pong actor
 async fn pong_actor(ctx: Arc<ActorCtx>, event: Message) -> Result<()> {
     match event {
-        Message::Ping =>
-            ctx.output
-                .write().await
-                .send(Message::Pong)
-                .map_err(|err| anyhow!(err))?,
+        Message::Ping => ctx.output.send(Message::Pong).map_err(|err| anyhow!(err))?,
         Message::Pong => bail!("I'm meant to be the ponger!")
     };
     Ok(())
@@ -73,7 +64,7 @@ async fn main() {
                 .filter(|msg| msg.is_ok())
                 .map(|msg| msg.unwrap())
         ),
-        move || ActorCtx { output: RwLock::new(tx_pong) },
+        move || ActorCtx { output: tx_pong },
         ping_actor,
         error_handler
     );
@@ -85,7 +76,7 @@ async fn main() {
                 .filter(|msg| msg.is_ok())
                 .map(|msg| msg.unwrap())
         )),
-        move || ActorCtx { output: RwLock::new(tx_ping) },
+        move || ActorCtx { output: tx_ping },
         pong_actor,
         error_handler
     );

--- a/examples/pingpong_threaded/src/main.rs
+++ b/examples/pingpong_threaded/src/main.rs
@@ -3,7 +3,6 @@ use message_worker::{Context, EmptyCtx};
 use message_worker::blocking::{listen, listen_with_error_handler};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
-use std::rc::Rc;
 
 struct ActorCtx { output: tokio::sync::broadcast::Sender<Message> }
 impl Context for ActorCtx {}
@@ -13,7 +12,7 @@ impl Context for ActorCtx {}
 enum Message { Ping, Pong }
 
 // Create the ping actor
-async fn ping_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
+async fn ping_actor(ctx: &mut ActorCtx, event: Message) -> Result<()> {
     match event {
         Message::Ping => bail!("I'm meant to be the pinger!"),
         Message::Pong => ctx.output.send(Message::Ping).map_err(|err| anyhow!(err))?
@@ -22,7 +21,7 @@ async fn ping_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
 }
 
 // Create the pong actor
-async fn pong_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
+async fn pong_actor(ctx: &mut ActorCtx, event: Message) -> Result<()> {
     match event {
         Message::Ping => ctx.output.send(Message::Pong).map_err(|err| anyhow!(err))?,
         Message::Pong => bail!("I'm meant to be the ponger!")
@@ -30,12 +29,12 @@ async fn pong_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
     Ok(())
 }
 
-async fn error_handler(_ctx: Rc<ActorCtx>, error: Error) -> bool {
+async fn error_handler(_ctx: &mut ActorCtx, error: Error) -> bool {
     eprintln!("There was an error sending an item: {:?}", error);
     true
 }
 
-async fn printer(_ctx: Rc<EmptyCtx>, msg: Message) -> Result<()> {
+async fn printer(_ctx: &mut EmptyCtx, msg: Message) -> Result<()> {
     println!("{:?}", msg);
     Ok(())
 }

--- a/examples/pingpong_threaded/src/main.rs
+++ b/examples/pingpong_threaded/src/main.rs
@@ -4,9 +4,8 @@ use message_worker::blocking::{listen, listen_with_error_handler};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 use std::rc::Rc;
-use std::cell::RefCell;
 
-struct ActorCtx { output: RefCell<tokio::sync::broadcast::Sender<Message>> }
+struct ActorCtx { output: tokio::sync::broadcast::Sender<Message> }
 impl Context for ActorCtx {}
 
 // Create our messages
@@ -17,11 +16,7 @@ enum Message { Ping, Pong }
 async fn ping_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
     match event {
         Message::Ping => bail!("I'm meant to be the pinger!"),
-        Message::Pong =>
-            ctx.output
-                .borrow_mut()
-                .send(Message::Ping)
-                .map_err(|err| anyhow!(err))?
+        Message::Pong => ctx.output.send(Message::Ping).map_err(|err| anyhow!(err))?
     };
     Ok(())
 }
@@ -29,11 +24,7 @@ async fn ping_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
 // Create the pong actor
 async fn pong_actor(ctx: Rc<ActorCtx>, event: Message) -> Result<()> {
     match event {
-        Message::Ping =>
-            ctx.output
-                .borrow_mut()
-                .send(Message::Pong)
-                .map_err(|err| anyhow!(err))?,
+        Message::Ping => ctx.output.send(Message::Pong).map_err(|err| anyhow!(err))?,
         Message::Pong => bail!("I'm meant to be the ponger!")
     };
     Ok(())
@@ -69,7 +60,7 @@ async fn main() {
         BroadcastStream::new(rx_ping)
             .filter(|msg| msg.is_ok())
             .map(|msg| msg.unwrap()),
-        move || ActorCtx { output: RefCell::new(tx_pong) },
+        move || ActorCtx { output: tx_pong },
         ping_actor,
         error_handler
     );
@@ -81,7 +72,7 @@ async fn main() {
                 .filter(|msg| msg.is_ok())
                 .map(|msg| msg.unwrap())
         ),
-        move || ActorCtx { output: RefCell::new(tx_ping) },
+        move || ActorCtx { output: tx_ping },
         pong_actor,
         error_handler
     );

--- a/src/context_holder.rs
+++ b/src/context_holder.rs
@@ -1,0 +1,41 @@
+use std::cell::UnsafeCell;
+
+use crate::Context;
+
+/// The `ContextHolder` is a wrapper type around the context of a listener.
+/// Because listeners only ever process events one-at-a-time and don't share their contexts,
+/// it should be fine to have a mutable reference to it within the listener.
+pub struct ContextHolder<Ctx: Context> {
+    ctx: UnsafeCell<&'static mut Ctx>
+}
+impl<Ctx: Context> ContextHolder<Ctx> {
+    pub fn new(ctx: Ctx) -> Self {
+        // This "leak" will be dropped when this holder struct is dropped.
+        let ctx: &'static mut Ctx = Box::leak(Box::new(ctx));
+
+        ContextHolder { ctx: UnsafeCell::new(ctx) }
+    }
+
+    /// # Safety
+    /// This is safe as long as there are no active references to the context.
+    /// This is ensured by making this function require a mutable reference to the
+    /// `ContextHolder`
+    pub fn get_mut(&mut self) -> &'static mut Ctx {
+        unsafe { &mut *self.ctx.get() }
+    }
+}
+
+impl<Ctx: Context> Drop for ContextHolder<Ctx> {
+    /// # Safety
+    /// This is safe as long as no references to the `ContextHolder` (or its inner context)
+    /// are alive. This object is only dropped when the listener is dropped, so that *should*
+    /// be fine.
+    fn drop(&mut self) {
+        let ctx_ref = self.get_mut();
+        let ctx_ptr = ctx_ref as *mut Ctx;
+
+        unsafe {
+            std::ptr::drop_in_place(ctx_ptr)
+        }
+    }
+}

--- a/src/non_blocking.rs
+++ b/src/non_blocking.rs
@@ -1,50 +1,51 @@
 use std::future::Future;
 use anyhow::{Result, Error};
-use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tokio_stream::{Stream, StreamExt};
 
 use crate::ThreadSafeContext;
+use crate::context_holder::ContextHolder;
 
 /// Creates a listener with the default error handler on its own system thread. It is safe to work
-/// with non-sync and non-send data in this listener. The callback (`handle_event`) will be invoked
+/// with non-sync and non-send data in this listener. The callback (`handle_message`) will be invoked
 /// whenever a new item from the `source` stream is emitted. The `context_factory` is a closure you
 /// must provide that returns the initial state for the listener.
-pub fn listen<Ctx, CtxFactory, Source, Event, HandleEventFuture>(
+pub fn listen<Ctx, CtxFactory, Source, Message, HandleMessageFuture>(
     source: Source,
     context_factory: CtxFactory,
-    handle_event: fn(Arc<Ctx>, Event) -> HandleEventFuture
+    handle_message: fn(&'static mut Ctx, Message) -> HandleMessageFuture
 ) -> JoinHandle<()> where
     Ctx: ThreadSafeContext,
     CtxFactory: (FnOnce() -> Ctx) + Send + 'static,
-    Source: Stream<Item = Event> + Unpin + Send + 'static,
-    Event: Send + 'static,
-    HandleEventFuture: Future<Output = Result<()>> + Send + 'static,
+    Source: Stream<Item =Message> + Unpin + Send + 'static,
+    Message: Send + 'static,
+    HandleMessageFuture: Future<Output = Result<()>> + Send + 'static,
 {
-    listen_with_error_handler(source, context_factory, handle_event, default_error_handler)
+    listen_with_error_handler(source, context_factory, handle_message, default_error_handler)
 }
 
 /// This is the same as `listen` but it allows a custom error handler to be defined.
 /// The error handler callback receives the context of the listener and the error that occurred.
 /// The error handler callback returns a boolean declaring if the listener should keep running or not.
-pub fn listen_with_error_handler<Ctx, CtxFactory, Source, Event, HandleEventFuture, HandleErrorFuture>(
+pub fn listen_with_error_handler<Ctx, CtxFactory, Source, Message, HandleMessageFuture, HandleErrorFuture>(
     mut source: Source,
     context_factory: CtxFactory,
-    handle_event: fn(Arc<Ctx>, Event) -> HandleEventFuture,
-    handle_error: fn(Arc<Ctx>, Error) -> HandleErrorFuture
+    handle_message: fn(&'static mut Ctx, Message) -> HandleMessageFuture,
+    handle_error: fn(&'static mut Ctx, Error) -> HandleErrorFuture
 ) -> JoinHandle<()> where
     Ctx: ThreadSafeContext,
     CtxFactory: (FnOnce() -> Ctx) + Send + 'static,
-    Source: Stream<Item = Event> + Unpin + Send + 'static,
-    Event: Send + 'static,
-    HandleEventFuture: Future<Output = Result<()>> + Send + 'static,
+    Source: Stream<Item =Message> + Unpin + Send + 'static,
+    Message: Send + 'static,
+    HandleMessageFuture: Future<Output = Result<()>> + Send + 'static,
     HandleErrorFuture: Future<Output = bool> + Send + 'static
 {
     tokio::spawn(async move {
-        let context = Arc::new(context_factory());
-        while let Some(event) = source.next().await {
-            if let Err(err) = handle_event(context.clone(), event).await {
-                if !handle_error(context.clone(), err).await {
+        let mut context = ContextHolder::new(context_factory());
+
+        while let Some(message) = source.next().await {
+            if let Err(err) = handle_message(context.get_mut(), message).await {
+                if !handle_error(context.get_mut(), err).await {
                     break;
                 }
             }
@@ -52,7 +53,7 @@ pub fn listen_with_error_handler<Ctx, CtxFactory, Source, Event, HandleEventFutu
     })
 }
 
-async fn default_error_handler<C: ThreadSafeContext>(_ctx: Arc<C>, err: Error) -> bool {
+async fn default_error_handler<Ctx: ThreadSafeContext>(_ctx: &mut Ctx, err: Error) -> bool {
     eprintln!("There was an error running the message worker: {:?}", err);
     false
 }
@@ -60,7 +61,7 @@ async fn default_error_handler<C: ThreadSafeContext>(_ctx: Arc<C>, err: Error) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, Arc};
     use std::borrow::Cow;
     use anyhow::{bail, anyhow};
 
@@ -93,7 +94,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::channel::<()>(1);
         let stream = ReceiverStream::new(rx);
 
-        async fn mock_handle<'a>(ctx: Arc<MockCtx>, _event: ()) -> Result<()> {
+        async fn mock_handle(ctx: &mut MockCtx, _msg: ()) -> Result<()> {
             ctx.test_res.send(ctx.internal_state).await?;
             Ok(())
         }
@@ -133,7 +134,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let stream = ReceiverStream::new(rx);
 
-        async fn mock_handle<'a>(ctx: Arc<MockCtx>, _event: ()) -> Result<()> {
+        async fn mock_handle(ctx: &mut MockCtx, _event: ()) -> Result<()> {
             {
                 let mut str = ctx.internal_state
                     .lock()
@@ -179,7 +180,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::channel::<u32>(1);
         let stream = ReceiverStream::new(rx);
 
-        async fn mock_handle<'a>(ctx: Arc<MockCtx>, event: u32) -> Result<()> {
+        async fn mock_handle(ctx: &mut MockCtx, event: u32) -> Result<()> {
             ctx.test_res.send(event).await?;
             Ok(())
         }
@@ -215,11 +216,11 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::channel::<()>(1);
         let stream = ReceiverStream::new(rx);
 
-        async fn mock_handle<'a>(_ctx: Arc<MockCtx>, _event: ()) -> Result<()> {
+        async fn mock_handle(_ctx: &mut MockCtx, _event: ()) -> Result<()> {
             bail!("rip")
         }
 
-        async fn mock_handle_error<'a>(ctx: Arc<MockCtx>, error: Error) -> bool {
+        async fn mock_handle_error(ctx: &mut MockCtx, error: Error) -> bool {
             ctx.test_res.send(error.to_string().into()).await.unwrap();
             false
         }
@@ -256,11 +257,11 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::channel::<Cow<'static, str>>(1);
         let stream = ReceiverStream::new(rx);
 
-        async fn mock_handle<'a>(_ctx: Arc<MockCtx>, event: Cow<'static, str>) -> Result<()> {
+        async fn mock_handle(_ctx: &mut MockCtx, event: Cow<'static, str>) -> Result<()> {
             bail!(event)
         }
 
-        async fn mock_handle_error<'a>(ctx: Arc<MockCtx>, error: Error) -> bool {
+        async fn mock_handle_error(ctx: &mut MockCtx, error: Error) -> bool {
             ctx.test_res.send(error.to_string().into()).await.unwrap();
             true
         }


### PR DESCRIPTION
We can use the one-at-a-time rule from the runtime and the predictable life cycle of a listener to avoid having to use `Arc`/`Rc` and any locks with data. We can now just give listener functions a mutable reference.

Sadly this does add some unsafe code, but it all seems legit.